### PR TITLE
Add multi-arch builds

### DIFF
--- a/7.4/build-images.sh
+++ b/7.4/build-images.sh
@@ -3,5 +3,5 @@
 set -x
 set -e
 
-(cd 7.4/base && docker build --rm --pull -t makasim/nginx-php-fpm:7.4 .)
-(cd 7.4/php-all-exts && docker build --rm -t makasim/nginx-php-fpm:7.4-all-exts .)
+(cd 7.4/base && docker buildx build --platform linux/amd64,linux/arm64 --rm --pull -t makasim/nginx-php-fpm:7.4 .)
+(cd 7.4/php-all-exts && docker buildx build --platform linux/amd64,linux/arm64--rm -t makasim/nginx-php-fpm:7.4-all-exts .)

--- a/8.0/build-images.sh
+++ b/8.0/build-images.sh
@@ -3,5 +3,5 @@
 set -x
 set -e
 
-(cd 8.0/base && docker build --rm --pull -t makasim/nginx-php-fpm:8.0 -t makasim/nginx-php-fpm:latest .)
-(cd 8.0/php-all-exts && docker build --rm -t makasim/nginx-php-fpm:8.0-all-exts -t makasim/nginx-php-fpm:latest-all-exts .)
+(cd 8.0/base && docker buildx build --platform linux/amd64,linux/arm64 --rm --pull -t makasim/nginx-php-fpm:8.0 -t makasim/nginx-php-fpm:latest .)
+(cd 8.0/php-all-exts && docker buildx build --platform linux/amd64,linux/arm64 --rm -t makasim/nginx-php-fpm:8.0-all-exts -t makasim/nginx-php-fpm:latest-all-exts .)

--- a/8.1/build-images.sh
+++ b/8.1/build-images.sh
@@ -3,5 +3,5 @@
 set -x
 set -e
 
-(cd 8.1/base && docker build --rm --pull -t makasim/nginx-php-fpm:8.1 -t makasim/nginx-php-fpm:latest .)
-(cd 8.1/php-all-exts && docker build --rm -t makasim/nginx-php-fpm:8.1-all-exts -t makasim/nginx-php-fpm:latest-all-exts .)
+(cd 8.1/base && docker buildx build --platform linux/amd64,linux/arm64 --rm --pull -t makasim/nginx-php-fpm:8.1 -t makasim/nginx-php-fpm:latest .)
+(cd 8.1/php-all-exts && docker buildx build --platform linux/amd64,linux/arm64 --rm -t makasim/nginx-php-fpm:8.1-all-exts -t makasim/nginx-php-fpm:latest-all-exts .)

--- a/8.2/build-images.sh
+++ b/8.2/build-images.sh
@@ -3,5 +3,5 @@
 set -x
 set -e
 
-(cd 8.2/base && docker build --rm --pull -t makasim/nginx-php-fpm:8.2 -t makasim/nginx-php-fpm:latest .)
-(cd 8.2/php-all-exts && docker build --rm -t makasim/nginx-php-fpm:8.2-all-exts -t makasim/nginx-php-fpm:latest-all-exts .)
+(cd 8.2/base && docker buildx build --platform linux/amd64,linux/arm64 --rm --pull -t makasim/nginx-php-fpm:8.2 -t makasim/nginx-php-fpm:latest .)
+(cd 8.2/php-all-exts && docker buildx build --platform linux/amd64,linux/arm64 --rm -t makasim/nginx-php-fpm:8.2-all-exts -t makasim/nginx-php-fpm:latest-all-exts .)


### PR DESCRIPTION
You would have to run `docker buildx create --use` once before running the build scripts, so not adding this line to them. Not sure how to make the script idempotent in this init stage.
